### PR TITLE
Reference obsoleted/impacted specs. See #28

### DIFF
--- a/draft-ietf-oauth-v2-1.md
+++ b/draft-ietf-oauth-v2-1.md
@@ -8,6 +8,7 @@ wg: OAuth Working Group
 kw: Internet-Draft
 cat: std
 area: Security
+obsoletes: 6749
 
 coding: us-ascii
 pi:


### PR DESCRIPTION
## This PR

obsoletes OAuth 2.0

NB: consider adding other specs obsoleted or updated by this one. 

Related to #28


cc: @aaronpk 