### PR TITLE
Reference HTTP Semantics instead of messaging

### DIFF
--- a/draft-ietf-oauth-v2-1.md
+++ b/draft-ietf-oauth-v2-1.md
@@ -213,7 +213,7 @@ directly with a server trusted by the photo-sharing service
 (authorization server), which issues the printing service delegation-
 specific credentials (access token).
 
-This specification is designed for use with HTTP ({{RFC7230}}).  The
+This specification is designed for use with HTTP ({{HTTP=RFC7231}}).  The
 use of OAuth over any protocol other than HTTP is out of scope.
 
 Since the publication of the OAuth 2.0 Authorization Framework ({{RFC6749}})


### PR DESCRIPTION
## This PR

- RFC7230 references HTTP Messaging aka HTTP/1.1. OAuth2.1 is agnostic of the HTTP version instead.

## Note

Consider that httpbis moves further definitions to [SEMANTICS](https://httpwg.org/http-core/draft-ietf-httpbis-semantics-latest.html#user.agent) including "user agent" and the ["https" scheme](https://httpwg.org/http-core/draft-ietf-httpbis-semantics-latest.html#https.uri) and provides some details on validation