### PR TITLE
editorial: use the ::boilerplate macro for bcp14

### DIFF
--- a/draft-ietf-oauth-v2-1.md
+++ b/draft-ietf-oauth-v2-1.md
@@ -544,11 +544,7 @@ See {{oauth-2-0-differences}} for more details on the differences from OAuth 2.0
 
 ## Notational Conventions
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
-"SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and
-"OPTIONAL" in this document are to be interpreted as described in
-BCP 14 {{RFC2119}} {{RFC8174}} when, and only when, they appear in all
-capitals, as shown here.
+{::boilerplate bcp14}
 
 This specification uses the Augmented Backus-Naur Form (ABNF)
 notation of {{RFC5234}}.  Additionally, the rule URI-reference is

--- a/draft-ietf-oauth-v2-1.md
+++ b/draft-ietf-oauth-v2-1.md
@@ -9,7 +9,6 @@ kw: Internet-Draft
 cat: std
 area: Security
 
-coding: us-ascii
 pi:
   toc: yes
   sortrefs: yes


### PR DESCRIPTION
## This PR

uses the ::boilerplate macro of https://github.com/cabo/kramdown-rfc2629