### PR TITLE
Fix minor incorrect references

### DIFF
--- a/draft-ietf-oauth-v2-1.md
+++ b/draft-ietf-oauth-v2-1.md
@@ -3309,7 +3309,7 @@ A non-normative list of changes from OAuth 2.0 is listed below:
 * Bearer token usage omits the use of bearer tokens in the query string of URIs
   as per Section 4.3.2 of {{I-D.ietf-oauth-security-topics}}
 * Refresh tokens for public clients must either be sender-constrained or one-time use
-  as per Section 4.12.2 of {{I-D.ietf-oauth-security-topics}}
+  as per Section 4.13.2 of {{I-D.ietf-oauth-security-topics}}
 
 ## Removal of the OAuth 2.0 Implicit grant
 

--- a/draft-ietf-oauth-v2-1.md
+++ b/draft-ietf-oauth-v2-1.md
@@ -88,7 +88,7 @@ informative:
 
   OpenID:
     title: OpenID Connect Core 1.0
-    target: https://openiD.net/specs/openiD-connect-core-1_0.html
+    target: https://openid.net/specs/openid-connect-core-1_0.html
     date: November 8, 2014
     author:
       - ins: N. Sakimora


### PR DESCRIPTION
An invalid link to the OpenID core spec has been fixed, as well as a section number referencing the `ietf-oauth-security-topics` draft.