### PR TITLE
Token encryption cannot replace TLS. See #64

### DIFF
--- a/draft-ietf-oauth-v2-1.md
+++ b/draft-ietf-oauth-v2-1.md
@@ -2419,14 +2419,11 @@ clear, as any information in them is at risk of disclosure.
 See "HTTP State Management Mechanism" {{RFC6265}} for security
 considerations about cookies.
 
-In some deployments, including those utilizing load balancers, the
-TLS connection to the resource server terminates prior to the actual
-server that provides the resource.  This could leave the token
-unprotected between the front-end server where the TLS connection
-terminates and the back-end server that provides the resource.  In
-such deployments, sufficient measures MUST be employed to ensure
-confidentiality of the access token between the front-end and back-end
-servers; encryption of the token is one such possible measure.
+When an OAuth server sits behind a reverse proxy
+that terminates TLS connections from clients,
+tokens can be spoofed or tampered.
+Mitigating measures includes using TLS along all the infrastructural
+components and implementing similar requirements at message level.
 
 
 ### Summary of Recommendations


### PR DESCRIPTION
## This PR

- token encryption can't replace TLS unless similar requirements are implemented (integrity, privacy, authenticity) ;
- suggest using TLS along the way, even when using TLS terminators;
- MUST does not define here a specific requirement 