### PR TITLE
s/relying party/resource server

### DIFF
--- a/draft-ietf-oauth-v2-1.md
+++ b/draft-ietf-oauth-v2-1.md
@@ -2644,7 +2644,7 @@ leaked.
 
 Authorization servers SHOULD issue bearer tokens
 that contain an audience restriction, scoping their use to the
-intended relying party or set of relying parties.
+intended resource server or set of resource servers.
 
 #### Don't pass bearer tokens in page URLs
 


### PR DESCRIPTION
since this is talking about access token audience, "resource server" is a more appropriate term than "relying party"

closes #169