### PR TITLE
Clarify authorization endpoint error responses

### DIFF
--- a/draft-ietf-oauth-v2-1.md
+++ b/draft-ietf-oauth-v2-1.md
@@ -1794,9 +1794,9 @@ The authorization server MUST validate the client identifier and redirect
 URI before redirecting an error response to the client. Once both have been
 validated, the authorization server redirects request errors using the error
 codes defined below. In particular, a missing `response_type` results in
-`invalid_request`, an unsupported `response_type` results in
-`unsupported_response_type`, and an invalid, unknown, or malformed `scope`
-results in `invalid_scope`.
+`invalid_request`, and an unsupported `response_type` results in
+`unsupported_response_type`. If the authorization server rejects a requested
+`scope` as invalid, unknown, or malformed, the error code is `invalid_scope`.
 
 An authorization server MUST reject requests without a `code_challenge` from public clients,
 and MUST reject such requests from other clients unless there is

--- a/draft-ietf-oauth-v2-1.md
+++ b/draft-ietf-oauth-v2-1.md
@@ -1784,6 +1784,19 @@ redirect URI, or if the client identifier is missing or invalid,
 the authorization server MUST NOT redirect the user agent to the
 invalid redirect URI and SHOULD inform the resource owner of the
 error, for example by displaying a message to the user in their browser.
+When returning an error response directly to the user agent, the
+authorization server SHOULD use the HTTP 400 (Bad Request) status code.
+The HTTP 401 (Unauthorized) status code used for client authentication
+errors at the token endpoint does not apply to authorization endpoint
+request errors.
+
+The authorization server MUST validate the client identifier and redirect
+URI before redirecting an error response to the client. Once both have been
+validated, the authorization server redirects request errors using the error
+codes defined below. In particular, a missing `response_type` results in
+`invalid_request`, an unsupported `response_type` results in
+`unsupported_response_type`, and an invalid, unknown, or malformed `scope`
+results in `invalid_scope`.
 
 An authorization server MUST reject requests without a `code_challenge` from public clients,
 and MUST reject such requests from other clients unless there is
@@ -1798,7 +1811,7 @@ authorization error response with `error` value set to
 algorithm not supported.
 
 If the resource owner denies the access request or if the request
-fails for reasons other than a missing or invalid redirect URI,
+fails after the client identifier and redirect URI have been validated,
 the authorization server informs the client by redirecting the user agent
 to the redirect URI and adding the following
 parameters to the query component of the redirect URI as described


### PR DESCRIPTION
Closes #253.

## Summary

- Require the client identifier and redirect URI to be validated before redirecting an authorization error response.
- Clarify the error codes for missing or unsupported `response_type` values and rejected `scope` values.
- Recommend HTTP 400 for errors returned directly to the user agent and distinguish them from token endpoint client-authentication errors that can use HTTP 401.

## Behavior Clarified

| Request condition | Authorization endpoint behavior |
| --- | --- |
| Missing `response_type` | Redirect to the validated redirect URI with `error=invalid_request`. |
| Missing or invalid `client_id` | Do not redirect; the direct response SHOULD use HTTP 400. |
| Unsupported `response_type` | Redirect to the validated redirect URI with `error=unsupported_response_type`. |
| Invalid or mismatching `redirect_uri` | Do not redirect; the direct response SHOULD use HTTP 400. |
| Invalid, unknown, or malformed `scope` | If the authorization server rejects it, redirect to the validated redirect URI with `error=invalid_scope`; the server can otherwise apply its scope policy. |

When the request contains `state` and an error is redirected, the existing requirement to return the exact `state` value still applies.

## Rationale

Section 4.1.2.1 currently says that the authorization server must not redirect when the client identifier is missing or invalid, while a later paragraph only excludes missing or invalid redirect URIs from redirected errors. Requiring both the client identifier and redirect URI to be validated before any error redirect removes that ambiguity and avoids turning the authorization endpoint into an open redirector.

The HTTP 401 behavior for client-authentication failures is defined for the token endpoint and does not apply to these authorization endpoint request errors.

OAuth permits an authorization server to fully or partially ignore requested scope according to its policy or the resource owner's instructions. The proposed `invalid_scope` mapping therefore applies when the authorization server rejects the requested scope.

## Validation

- `git diff --check`
- `make`
  - `kramdown-rfc`: OK
  - `xml2rfc-txt`: OK
  - `xml2rfc-html`: OK